### PR TITLE
Removed unused constant

### DIFF
--- a/aiokafka/codec.py
+++ b/aiokafka/codec.py
@@ -7,7 +7,6 @@ from typing_extensions import Buffer
 
 _XERIAL_V1_HEADER = (-126, b"S", b"N", b"A", b"P", b"P", b"Y", 0, 1, 1)
 _XERIAL_V1_FORMAT = "bccccccBii"
-ZSTD_MAX_OUTPUT_SIZE = 1024 * 1024
 
 try:
     import cramjam


### PR DESCRIPTION
Removed the now unused constant `ZSTD_MAX_OUTPUT_SIZE`

### Changes

I removed the now unused constant `ZSTD_MAX_OUTPUT_SIZE` since it is no longer referenced anywhere. 

### Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
